### PR TITLE
Added assert option for verilator testbench targets

### DIFF
--- a/bsg_async/bsg_async_credit_counter.core
+++ b/bsg_async/bsg_async_credit_counter.core
@@ -43,7 +43,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_async/bsg_async_fifo.core
+++ b/bsg_async/bsg_async_fifo.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_async/bsg_async_ptr_gray.core
+++ b/bsg_async/bsg_async_ptr_gray.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_async/bsg_launch_sync_sync_.core
+++ b/bsg_async/bsg_launch_sync_sync_.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_async/bsg_sync_sync_.core
+++ b/bsg_async/bsg_sync_sync_.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_1_to_n_tagged.core
+++ b/bsg_dataflow/bsg_1_to_n_tagged.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_1_to_n_tagged_fifo.core
+++ b/bsg_dataflow/bsg_1_to_n_tagged_fifo.core
@@ -46,7 +46,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_1_to_n_tagged_fifo_shared.core
+++ b/bsg_dataflow/bsg_1_to_n_tagged_fifo_shared.core
@@ -51,7 +51,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_8b10b_decode_comb.core
+++ b/bsg_dataflow/bsg_8b10b_decode_comb.core
@@ -36,7 +36,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 provider:

--- a/bsg_dataflow/bsg_8b10b_encode_comb.core
+++ b/bsg_dataflow/bsg_8b10b_encode_comb.core
@@ -36,7 +36,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 provider:

--- a/bsg_dataflow/bsg_8b10b_shift_decoder.core
+++ b/bsg_dataflow/bsg_8b10b_shift_decoder.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 provider:

--- a/bsg_dataflow/bsg_channel_narrow.core
+++ b/bsg_dataflow/bsg_channel_narrow.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_channel_tunnel.core
+++ b/bsg_dataflow/bsg_channel_tunnel.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_channel_tunnel_in.core
+++ b/bsg_dataflow/bsg_channel_tunnel_in.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_channel_tunnel_out.core
+++ b/bsg_dataflow/bsg_channel_tunnel_out.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_channel_tunnel_wormhole.core
+++ b/bsg_dataflow/bsg_channel_tunnel_wormhole.core
@@ -55,7 +55,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_compare_and_swap.core
+++ b/bsg_dataflow/bsg_compare_and_swap.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_credit_to_token.core
+++ b/bsg_dataflow/bsg_credit_to_token.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_1r1w_large.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_large.core
@@ -47,7 +47,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_1r1w_large_banked.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_large_banked.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_1r1w_narrowed.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_narrowed.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.core
@@ -43,7 +43,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_1r1w_small.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_small.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_1r1w_small_credit_on_input.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_credit_on_input.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_1r1w_small_hardened.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_hardened.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_1r1w_small_unhardened.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_unhardened.core
@@ -43,7 +43,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_1rw_large.core
+++ b/bsg_dataflow/bsg_fifo_1rw_large.core
@@ -43,7 +43,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_bypass.core
+++ b/bsg_dataflow/bsg_fifo_bypass.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_reorder.core
+++ b/bsg_dataflow/bsg_fifo_reorder.core
@@ -45,7 +45,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_shift_datapath.core
+++ b/bsg_dataflow/bsg_fifo_shift_datapath.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_fifo_tracker.core
+++ b/bsg_dataflow/bsg_fifo_tracker.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_flatten_2D_array.core
+++ b/bsg_dataflow/bsg_flatten_2D_array.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_flow_convert.core
+++ b/bsg_dataflow/bsg_flow_convert.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_flow_counter.core
+++ b/bsg_dataflow/bsg_flow_counter.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_make_2D_array.core
+++ b/bsg_dataflow/bsg_make_2D_array.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_one_fifo.core
+++ b/bsg_dataflow/bsg_one_fifo.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_parallel_in_serial_out.core
+++ b/bsg_dataflow/bsg_parallel_in_serial_out.core
@@ -46,7 +46,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_parallel_in_serial_out_dynamic.core
+++ b/bsg_dataflow/bsg_parallel_in_serial_out_dynamic.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.core
+++ b/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.core
@@ -43,7 +43,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_permute_box.core
+++ b/bsg_dataflow/bsg_permute_box.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_ready_to_credit_flow_converter.core
+++ b/bsg_dataflow/bsg_ready_to_credit_flow_converter.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_relay_fifo.core
+++ b/bsg_dataflow/bsg_relay_fifo.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_round_robin_1_to_n.core
+++ b/bsg_dataflow/bsg_round_robin_1_to_n.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_round_robin_2_to_2.core
+++ b/bsg_dataflow/bsg_round_robin_2_to_2.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_round_robin_fifo_to_fifo.core
+++ b/bsg_dataflow/bsg_round_robin_fifo_to_fifo.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_round_robin_n_to_1.core
+++ b/bsg_dataflow/bsg_round_robin_n_to_1.core
@@ -46,7 +46,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_sbox.core
+++ b/bsg_dataflow/bsg_sbox.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_scatter_gather.core
+++ b/bsg_dataflow/bsg_scatter_gather.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_serial_in_parallel_out.core
+++ b/bsg_dataflow/bsg_serial_in_parallel_out.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.core
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.core
@@ -46,7 +46,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_serial_in_parallel_out_full.core
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_full.core
@@ -45,7 +45,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.core
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.core
@@ -43,7 +43,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_shift_reg.core
+++ b/bsg_dataflow/bsg_shift_reg.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_sort_4.core
+++ b/bsg_dataflow/bsg_sort_4.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_sort_stable.core
+++ b/bsg_dataflow/bsg_sort_stable.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_two_buncher.core
+++ b/bsg_dataflow/bsg_two_buncher.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_dataflow/bsg_two_fifo.core
+++ b/bsg_dataflow/bsg_two_fifo.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_abs.core
+++ b/bsg_misc/bsg_abs.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_adder_cin.core
+++ b/bsg_misc/bsg_adder_cin.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_adder_one_hot.core
+++ b/bsg_misc/bsg_adder_one_hot.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
     parameters: 
       - width_p=4

--- a/bsg_misc/bsg_adder_ripple_carry.core
+++ b/bsg_misc/bsg_adder_ripple_carry.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_and.core
+++ b/bsg_misc/bsg_and.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_arb_fixed.core
+++ b/bsg_misc/bsg_arb_fixed.core
@@ -43,7 +43,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_arb_round_robin.core
+++ b/bsg_misc/bsg_arb_round_robin.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_array_concentrate_static.core
+++ b/bsg_misc/bsg_array_concentrate_static.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_array_reverse.core
+++ b/bsg_misc/bsg_array_reverse.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_binary_plus_one_to_gray.core
+++ b/bsg_misc/bsg_binary_plus_one_to_gray.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint -Wno-UNOPTFLAT]
+        verilator_options: [-Wno-lint --assert -Wno-UNOPTFLAT]
     toplevel: test_bsg
     parameters: 
       - width_p=3

--- a/bsg_misc/bsg_buf.core
+++ b/bsg_misc/bsg_buf.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_buf_ctrl.core
+++ b/bsg_misc/bsg_buf_ctrl.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_circular_ptr.core
+++ b/bsg_misc/bsg_circular_ptr.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_clkbuf.core
+++ b/bsg_misc/bsg_clkbuf.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_clkgate_optional.core
+++ b/bsg_misc/bsg_clkgate_optional.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 provider :

--- a/bsg_misc/bsg_concentrate_static.core
+++ b/bsg_misc/bsg_concentrate_static.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_clear_up.core
+++ b/bsg_misc/bsg_counter_clear_up.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_clear_up_one_hot.core
+++ b/bsg_misc/bsg_counter_clear_up_one_hot.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_clock_downsample.core
+++ b/bsg_misc/bsg_counter_clock_downsample.core
@@ -48,7 +48,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_dynamic_limit.core
+++ b/bsg_misc/bsg_counter_dynamic_limit.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
     parameters: 
       - width_p=3

--- a/bsg_misc/bsg_counter_dynamic_limit_en.core
+++ b/bsg_misc/bsg_counter_dynamic_limit_en.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_overflow_en.core
+++ b/bsg_misc/bsg_counter_overflow_en.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_overflow_set_en.core
+++ b/bsg_misc/bsg_counter_overflow_set_en.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_set_down.core
+++ b/bsg_misc/bsg_counter_set_down.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_set_en.core
+++ b/bsg_misc/bsg_counter_set_en.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_up_down.core
+++ b/bsg_misc/bsg_counter_up_down.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counter_up_down_variable.core
+++ b/bsg_misc/bsg_counter_up_down_variable.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_counting_leading_zeros.core
+++ b/bsg_misc/bsg_counting_leading_zeros.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_crossbar_control_basic_o_by_i.core
+++ b/bsg_misc/bsg_crossbar_control_basic_o_by_i.core
@@ -46,7 +46,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_crossbar_o_by_i.core
+++ b/bsg_misc/bsg_crossbar_o_by_i.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_cycle_counter.core
+++ b/bsg_misc/bsg_cycle_counter.core
@@ -36,7 +36,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
     parameters: 
       - width_p=3

--- a/bsg_misc/bsg_decode.core
+++ b/bsg_misc/bsg_decode.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_decode_with_v.core
+++ b/bsg_misc/bsg_decode_with_v.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dff.core
+++ b/bsg_misc/bsg_dff.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
     parameters: 
       - width_p=3

--- a/bsg_misc/bsg_dff_async_reset.core
+++ b/bsg_misc/bsg_dff_async_reset.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dff_chain.core
+++ b/bsg_misc/bsg_dff_chain.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dff_en.core
+++ b/bsg_misc/bsg_dff_en.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dff_en_bypass.core
+++ b/bsg_misc/bsg_dff_en_bypass.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dff_gatestack.core
+++ b/bsg_misc/bsg_dff_gatestack.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dff_negedge_reset.core
+++ b/bsg_misc/bsg_dff_negedge_reset.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dff_reset.core
+++ b/bsg_misc/bsg_dff_reset.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dff_reset_en.core
+++ b/bsg_misc/bsg_dff_reset_en.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
     parameters: 
       - width_p=3

--- a/bsg_misc/bsg_dff_reset_en_bypass.core
+++ b/bsg_misc/bsg_dff_reset_en_bypass.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dff_reset_set_clear.core
+++ b/bsg_misc/bsg_dff_reset_set_clear.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_dlatch.core
+++ b/bsg_misc/bsg_dlatch.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_edge_detect.core
+++ b/bsg_misc/bsg_edge_detect.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_encode_one_hot.core
+++ b/bsg_misc/bsg_encode_one_hot.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint -Wno-UNOPTFLAT]
+        verilator_options: [-Wno-lint --assert -Wno-UNOPTFLAT]
     toplevel: test_bsg
     parameters: 
       - width_p=3

--- a/bsg_misc/bsg_expand_bitmask.core
+++ b/bsg_misc/bsg_expand_bitmask.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_gray_to_binary.core
+++ b/bsg_misc/bsg_gray_to_binary.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint -Wno-UNOPTFLAT]
+        verilator_options: [-Wno-lint --assert -Wno-UNOPTFLAT]
     toplevel: test_bsg
     parameters: 
       - width_p=3

--- a/bsg_misc/bsg_hash_bank.core
+++ b/bsg_misc/bsg_hash_bank.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT -Wno-MODDUP]
+        verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT -Wno-MODDUP --assert]
     toplevel: tb
 
 parameters:

--- a/bsg_misc/bsg_hash_bank_reverse.core
+++ b/bsg_misc/bsg_hash_bank_reverse.core
@@ -43,7 +43,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_id_pool.core
+++ b/bsg_misc/bsg_id_pool.core
@@ -44,7 +44,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_idiv_iterative.core
+++ b/bsg_misc/bsg_idiv_iterative.core
@@ -45,7 +45,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_idiv_iterative_controller.core
+++ b/bsg_misc/bsg_idiv_iterative_controller.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_inv.core
+++ b/bsg_misc/bsg_inv.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_less_than.core
+++ b/bsg_misc/bsg_less_than.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_level_shift_up_down_sink.core
+++ b/bsg_misc/bsg_level_shift_up_down_sink.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_level_shift_up_down_source.core
+++ b/bsg_misc/bsg_level_shift_up_down_source.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_lfsr.core
+++ b/bsg_misc/bsg_lfsr.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_locking_arb_fixed.core
+++ b/bsg_misc/bsg_locking_arb_fixed.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_lru_pseudo_tree_backup.core
+++ b/bsg_misc/bsg_lru_pseudo_tree_backup.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_lru_pseudo_tree_decode.core
+++ b/bsg_misc/bsg_lru_pseudo_tree_decode.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_lru_pseudo_tree_encode.core
+++ b/bsg_misc/bsg_lru_pseudo_tree_encode.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_mux.core
+++ b/bsg_misc/bsg_mux.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_mux2_gatestack.core
+++ b/bsg_misc/bsg_mux2_gatestack.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_mux_bitwise.core
+++ b/bsg_misc/bsg_mux_bitwise.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_mux_butterfly.core
+++ b/bsg_misc/bsg_mux_butterfly.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_mux_one_hot.core
+++ b/bsg_misc/bsg_mux_one_hot.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_mux_segmented.core
+++ b/bsg_misc/bsg_mux_segmented.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_muxi2_gatestack.core
+++ b/bsg_misc/bsg_muxi2_gatestack.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_nand.core
+++ b/bsg_misc/bsg_nand.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_nor2.core
+++ b/bsg_misc/bsg_nor2.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_nor3.core
+++ b/bsg_misc/bsg_nor3.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_pg_tree.core
+++ b/bsg_misc/bsg_pg_tree.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_popcount.core
+++ b/bsg_misc/bsg_popcount.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_priority_encode.core
+++ b/bsg_misc/bsg_priority_encode.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_priority_encode_one_hot_out.core
+++ b/bsg_misc/bsg_priority_encode_one_hot_out.core
@@ -42,7 +42,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_reduce.core
+++ b/bsg_misc/bsg_reduce.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_reduce_segmented.core
+++ b/bsg_misc/bsg_reduce_segmented.core
@@ -41,7 +41,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_rotate_left.core
+++ b/bsg_misc/bsg_rotate_left.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_rotate_right.core
+++ b/bsg_misc/bsg_rotate_right.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_round_robin_arb.core
+++ b/bsg_misc/bsg_round_robin_arb.core
@@ -43,7 +43,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_scan.core
+++ b/bsg_misc/bsg_scan.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_strobe.core
+++ b/bsg_misc/bsg_strobe.core
@@ -47,7 +47,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_swap.core
+++ b/bsg_misc/bsg_swap.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_thermometer_count.core
+++ b/bsg_misc/bsg_thermometer_count.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
     parameters: 
       - width_p=3

--- a/bsg_misc/bsg_tiehi.core
+++ b/bsg_misc/bsg_tiehi.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_tielo.core
+++ b/bsg_misc/bsg_tielo.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_transpose.core
+++ b/bsg_misc/bsg_transpose.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_unconcentrate_static.core
+++ b/bsg_misc/bsg_unconcentrate_static.core
@@ -39,7 +39,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_wait_after_reset.core
+++ b/bsg_misc/bsg_wait_after_reset.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-WIDTH -Wno-MULTIDRIVEN]
+        verilator_options: [-Wno-WIDTH -Wno-MULTIDRIVEN --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_wait_cycles.core
+++ b/bsg_misc/bsg_wait_cycles.core
@@ -40,7 +40,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-WIDTH -Wno-MULTIDRIVEN]
+        verilator_options: [-Wno-WIDTH -Wno-MULTIDRIVEN --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_xnor.core
+++ b/bsg_misc/bsg_xnor.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:

--- a/bsg_misc/bsg_xor.core
+++ b/bsg_misc/bsg_xor.core
@@ -38,7 +38,7 @@ targets:
     filesets: [rtl, tb]
     tools:
       verilator:
-        verilator_options: [-Wno-lint]
+        verilator_options: [-Wno-lint --assert]
     toplevel: test_bsg
 
 parameters:


### PR DESCRIPTION
Missed this out in the initial version of the cores. Simply added assert tag in using
```
grep -rl Wno-lint . | xargs sed -i "" 's/Wno-lint/Wno-lint --assert/g'
```