### PR TITLE
Additional warnings in lint targets

### DIFF
--- a/bsg_async/bsg_async_credit_counter.core
+++ b/bsg_async/bsg_async_credit_counter.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_async_credit_counter
     parameters: 

--- a/bsg_async/bsg_async_fifo.core
+++ b/bsg_async/bsg_async_fifo.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_async_fifo
     parameters: 

--- a/bsg_async/bsg_async_ptr_gray.core
+++ b/bsg_async/bsg_async_ptr_gray.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_async_ptr_gray
     parameters: 
       - lg_size_p=2

--- a/bsg_async/bsg_launch_sync_sync.core
+++ b/bsg_async/bsg_launch_sync_sync.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_launch_sync_sync
     parameters: 

--- a/bsg_async/bsg_sync_sync.core
+++ b/bsg_async/bsg_sync_sync.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_sync_sync
     parameters: 

--- a/bsg_cache/bsg_cache.core
+++ b/bsg_cache/bsg_cache.core
@@ -34,6 +34,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING -Wno-MODDUP]
     toplevel: bsg_cache
 

--- a/bsg_cache/bsg_cache_decode.core
+++ b/bsg_cache/bsg_cache_decode.core
@@ -21,6 +21,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPT]
     toplevel: bsg_cache_decode
 

--- a/bsg_cache/bsg_cache_dma.core
+++ b/bsg_cache/bsg_cache_dma.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING -Wno-LITENDIAN]
     toplevel: bsg_cache_dma
     parameters: 

--- a/bsg_cache/bsg_cache_miss.core
+++ b/bsg_cache/bsg_cache_miss.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING]
     toplevel: bsg_cache_miss
     parameters: 

--- a/bsg_cache/bsg_cache_non_blocking.core
+++ b/bsg_cache/bsg_cache_non_blocking.core
@@ -30,6 +30,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-PINMISSING -Wno-MODDUP]
     toplevel: bsg_cache_non_blocking
     parameters:

--- a/bsg_cache/bsg_cache_non_blocking_data_mem.core
+++ b/bsg_cache/bsg_cache_non_blocking_data_mem.core
@@ -27,6 +27,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING -Wno-SELRANGE -Wno-LITENDIAN]
     toplevel: bsg_cache_non_blocking_data_mem
     parameters:

--- a/bsg_cache/bsg_cache_non_blocking_decode.core
+++ b/bsg_cache/bsg_cache_non_blocking_decode.core
@@ -21,6 +21,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPT]
     toplevel: bsg_cache_non_blocking_decode
 

--- a/bsg_cache/bsg_cache_non_blocking_dma.core
+++ b/bsg_cache/bsg_cache_non_blocking_dma.core
@@ -26,6 +26,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING -Wno-LITENDIAN]
     toplevel: bsg_cache_non_blocking_dma
     parameters:

--- a/bsg_cache/bsg_cache_non_blocking_mhu.core
+++ b/bsg_cache/bsg_cache_non_blocking_mhu.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         # verilator_options: [-Wno-WIDTH -Wno-PINMISSING -Wno-MODDUP]
     toplevel: bsg_cache_non_blocking_mhu
     parameters:

--- a/bsg_cache/bsg_cache_non_blocking_miss_fifo.core
+++ b/bsg_cache/bsg_cache_non_blocking_miss_fifo.core
@@ -26,6 +26,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_cache_non_blocking_miss_fifo
     parameters:

--- a/bsg_cache/bsg_cache_non_blocking_stat_mem.core
+++ b/bsg_cache/bsg_cache_non_blocking_stat_mem.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_cache_non_blocking_stat_mem
     parameters:

--- a/bsg_cache/bsg_cache_non_blocking_tag_mem.core
+++ b/bsg_cache/bsg_cache_non_blocking_tag_mem.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_cache_non_blocking_tag_mem
     parameters:

--- a/bsg_cache/bsg_cache_non_blocking_tl_stage.core
+++ b/bsg_cache/bsg_cache_non_blocking_tl_stage.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-MODDUP]
     toplevel: bsg_cache_non_blocking_tl_stage
     parameters:

--- a/bsg_cache/bsg_cache_sbuf.core
+++ b/bsg_cache/bsg_cache_sbuf.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-MODDUP --debug]
     toplevel: bsg_cache_sbuf
     parameters:

--- a/bsg_cache/bsg_cache_sbuf_queue.core
+++ b/bsg_cache/bsg_cache_sbuf_queue.core
@@ -21,6 +21,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_cache_sbuf_queue
     parameters:
       - width_p= 2

--- a/bsg_cache/bsg_cache_to_axi.core
+++ b/bsg_cache/bsg_cache_to_axi.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-WIDTHCONCAT -Wno-PINMISSING -Wno-UNOPTFLAT]
     toplevel: bsg_cache_to_axi
     parameters:

--- a/bsg_cache/bsg_cache_to_axi_rx.core
+++ b/bsg_cache/bsg_cache_to_axi_rx.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING]
     toplevel: bsg_cache_to_axi_rx
     parameters:

--- a/bsg_cache/bsg_cache_to_axi_tx.core
+++ b/bsg_cache/bsg_cache_to_axi_tx.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN]
     toplevel: bsg_cache_to_axi_tx
     parameters:

--- a/bsg_cache/bsg_cache_to_dram_ctrl.core
+++ b/bsg_cache/bsg_cache_to_dram_ctrl.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN]
     toplevel: bsg_cache_to_dram_ctrl
     parameters: 

--- a/bsg_cache/bsg_cache_to_dram_ctrl_rx.core
+++ b/bsg_cache/bsg_cache_to_dram_ctrl_rx.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT]
     toplevel: bsg_cache_to_dram_ctrl_rx
     parameters: 

--- a/bsg_cache/bsg_cache_to_dram_ctrl_tx.core
+++ b/bsg_cache/bsg_cache_to_dram_ctrl_tx.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN]
     toplevel: bsg_cache_to_dram_ctrl_tx
     parameters: 

--- a/bsg_cache/bsg_cache_to_test_dram.core
+++ b/bsg_cache/bsg_cache_to_test_dram.core
@@ -28,6 +28,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-WIDTHCONCAT]
     toplevel: bsg_cache_to_test_dram
     parameters: 

--- a/bsg_cache/bsg_cache_to_test_dram_rx.core
+++ b/bsg_cache/bsg_cache_to_test_dram_rx.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_cache_to_test_dram_rx
     parameters: 

--- a/bsg_cache/bsg_cache_to_test_dram_rx_reorder.core
+++ b/bsg_cache/bsg_cache_to_test_dram_rx_reorder.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING]
     toplevel: bsg_cache_to_test_dram_rx_reorder
     parameters: 

--- a/bsg_cache/bsg_cache_to_test_dram_tx.core
+++ b/bsg_cache/bsg_cache_to_test_dram_tx.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_cache_to_test_dram_tx
     parameters: 

--- a/bsg_cache/bsg_nonsynth_cache_axe_tracer.core
+++ b/bsg_cache/bsg_nonsynth_cache_axe_tracer.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         # verilator_options: [-Wno-WIDTH -Wno-LITENDIAN]
     toplevel: bsg_nonsynth_cache_axe_tracer
     parameters: 

--- a/bsg_dataflow/bsg_1_to_n_tagged.core
+++ b/bsg_dataflow/bsg_1_to_n_tagged.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_1_to_n_tagged
     parameters: 

--- a/bsg_dataflow/bsg_1_to_n_tagged_fifo.core
+++ b/bsg_dataflow/bsg_1_to_n_tagged_fifo.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_1_to_n_tagged_fifo
     parameters: 

--- a/bsg_dataflow/bsg_1_to_n_tagged_fifo_shared.core
+++ b/bsg_dataflow/bsg_1_to_n_tagged_fifo_shared.core
@@ -38,6 +38,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-PINMISSING]
     toplevel: bsg_1_to_n_tagged_fifo_shared
     parameters: 

--- a/bsg_dataflow/bsg_8b10b_decode_comb.core
+++ b/bsg_dataflow/bsg_8b10b_decode_comb.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_8b10b_decode_comb
 
   verilator_tb:

--- a/bsg_dataflow/bsg_8b10b_encode_comb.core
+++ b/bsg_dataflow/bsg_8b10b_encode_comb.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_8b10b_encode_comb
 
   verilator_tb:

--- a/bsg_dataflow/bsg_8b10b_shift_decoder.core
+++ b/bsg_dataflow/bsg_8b10b_shift_decoder.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_8b10b_shift_decoder
 
   verilator_tb:

--- a/bsg_dataflow/bsg_channel_narrow.core
+++ b/bsg_dataflow/bsg_channel_narrow.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_channel_narrow
     parameters: 
       - width_in_p=2

--- a/bsg_dataflow/bsg_channel_tunnel.core
+++ b/bsg_dataflow/bsg_channel_tunnel.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-SELRANGE]
     toplevel: bsg_channel_tunnel
     parameters: 

--- a/bsg_dataflow/bsg_channel_tunnel_in.core
+++ b/bsg_dataflow/bsg_channel_tunnel_in.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-SELRANGE]
     toplevel: bsg_channel_tunnel_in
     parameters: 

--- a/bsg_dataflow/bsg_channel_tunnel_out.core
+++ b/bsg_dataflow/bsg_channel_tunnel_out.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-SELRANGE]
     toplevel: bsg_channel_tunnel_out
     parameters: 

--- a/bsg_dataflow/bsg_channel_tunnel_wormhole.core
+++ b/bsg_dataflow/bsg_channel_tunnel_wormhole.core
@@ -38,6 +38,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING -Wno-SELRANGE -Wno-LITENDIAN]
     toplevel: bsg_channel_tunnel_wormhole
     parameters: 

--- a/bsg_dataflow/bsg_compare_and_swap.core
+++ b/bsg_dataflow/bsg_compare_and_swap.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_compare_and_swap
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_credit_to_token.core
+++ b/bsg_dataflow/bsg_credit_to_token.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_credit_to_token
     parameters: 

--- a/bsg_dataflow/bsg_fifo_1r1w_large.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_large.core
@@ -36,6 +36,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT]
     toplevel: bsg_fifo_1r1w_large
     parameters: 

--- a/bsg_dataflow/bsg_fifo_1r1w_large_banked.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_large_banked.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         # verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT]
     toplevel: bsg_fifo_1r1w_large_banked
     parameters: 

--- a/bsg_dataflow/bsg_fifo_1r1w_narrowed.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_narrowed.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_fifo_1r1w_narrowed
     parameters: 

--- a/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_pseudo_large.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_fifo_1r1w_pseudo_large
     parameters: 

--- a/bsg_dataflow/bsg_fifo_1r1w_small.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_small.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_fifo_1r1w_small
     parameters: 

--- a/bsg_dataflow/bsg_fifo_1r1w_small_credit_on_input.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_credit_on_input.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_fifo_1r1w_small_credit_on_input
     parameters: 

--- a/bsg_dataflow/bsg_fifo_1r1w_small_hardened.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_hardened.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_fifo_1r1w_small_hardened
     parameters: 

--- a/bsg_dataflow/bsg_fifo_1r1w_small_unhardened.core
+++ b/bsg_dataflow/bsg_fifo_1r1w_small_unhardened.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_fifo_1r1w_small_unhardened
     parameters: 

--- a/bsg_dataflow/bsg_fifo_1rw_large.core
+++ b/bsg_dataflow/bsg_fifo_1rw_large.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_fifo_1rw_large
     parameters: 

--- a/bsg_dataflow/bsg_fifo_bypass.core
+++ b/bsg_dataflow/bsg_fifo_bypass.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_fifo_bypass
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_fifo_reorder.core
+++ b/bsg_dataflow/bsg_fifo_reorder.core
@@ -34,6 +34,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_fifo_reorder
     parameters: 

--- a/bsg_dataflow/bsg_fifo_shift_datapath.core
+++ b/bsg_dataflow/bsg_fifo_shift_datapath.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-BLKANDNBLK]
     toplevel: bsg_fifo_shift_datapath
     parameters: 

--- a/bsg_dataflow/bsg_fifo_tracker.core
+++ b/bsg_dataflow/bsg_fifo_tracker.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_fifo_tracker
     parameters:
       - els_p=2

--- a/bsg_dataflow/bsg_flatten_2D_array.core
+++ b/bsg_dataflow/bsg_flatten_2D_array.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_flatten_2D_array
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_flow_convert.core
+++ b/bsg_dataflow/bsg_flow_convert.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_flow_convert
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_flow_counter.core
+++ b/bsg_dataflow/bsg_flow_counter.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_flow_counter
     parameters: 

--- a/bsg_dataflow/bsg_make_2D_array.core
+++ b/bsg_dataflow/bsg_make_2D_array.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_make_2D_array
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_one_fifo.core
+++ b/bsg_dataflow/bsg_one_fifo.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_one_fifo
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_parallel_in_serial_out.core
+++ b/bsg_dataflow/bsg_parallel_in_serial_out.core
@@ -35,6 +35,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING]
     toplevel: bsg_parallel_in_serial_out
     parameters: 

--- a/bsg_dataflow/bsg_parallel_in_serial_out_dynamic.core
+++ b/bsg_dataflow/bsg_parallel_in_serial_out_dynamic.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING]
     toplevel: bsg_parallel_in_serial_out_dynamic
     parameters: 

--- a/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.core
+++ b/bsg_dataflow/bsg_parallel_in_serial_out_passthrough.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_parallel_in_serial_out_passthrough
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_permute_box.core
+++ b/bsg_dataflow/bsg_permute_box.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_permute_box
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_ready_to_credit_flow_converter.core
+++ b/bsg_dataflow/bsg_ready_to_credit_flow_converter.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_ready_to_credit_flow_converter
     parameters: 

--- a/bsg_dataflow/bsg_relay_fifo.core
+++ b/bsg_dataflow/bsg_relay_fifo.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_relay_fifo
     parameters: 

--- a/bsg_dataflow/bsg_round_robin_1_to_n.core
+++ b/bsg_dataflow/bsg_round_robin_1_to_n.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_round_robin_1_to_n
     parameters: 

--- a/bsg_dataflow/bsg_round_robin_2_to_2.core
+++ b/bsg_dataflow/bsg_round_robin_2_to_2.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_round_robin_2_to_2
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_round_robin_fifo_to_fifo.core
+++ b/bsg_dataflow/bsg_round_robin_fifo_to_fifo.core
@@ -35,6 +35,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_round_robin_fifo_to_fifo
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_round_robin_n_to_1.core
+++ b/bsg_dataflow/bsg_round_robin_n_to_1.core
@@ -35,6 +35,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_round_robin_n_to_1
     parameters: 

--- a/bsg_dataflow/bsg_sbox.core
+++ b/bsg_dataflow/bsg_sbox.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_sbox
     parameters: 
       - num_channels_p=2

--- a/bsg_dataflow/bsg_scatter_gather.core
+++ b/bsg_dataflow/bsg_scatter_gather.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_scatter_gather
     parameters: 
       - vec_size_lp=2

--- a/bsg_dataflow/bsg_serial_in_parallel_out.core
+++ b/bsg_dataflow/bsg_serial_in_parallel_out.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_serial_in_parallel_out
     parameters: 

--- a/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.core
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.core
@@ -35,6 +35,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_serial_in_parallel_out_dynamic
     parameters: 

--- a/bsg_dataflow/bsg_serial_in_parallel_out_full.core
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_full.core
@@ -34,6 +34,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_serial_in_parallel_out_full
     parameters: 

--- a/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.core
+++ b/bsg_dataflow/bsg_serial_in_parallel_out_passthrough.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_serial_in_parallel_out_passthrough
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_shift_reg.core
+++ b/bsg_dataflow/bsg_shift_reg.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_shift_reg
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_sort_4.core
+++ b/bsg_dataflow/bsg_sort_4.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-PINMISSING]
     toplevel: bsg_sort_4
     parameters: 

--- a/bsg_dataflow/bsg_sort_stable.core
+++ b/bsg_dataflow/bsg_sort_stable.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-PINMISSING]
     toplevel: bsg_sort_stable
     parameters: 

--- a/bsg_dataflow/bsg_two_buncher.core
+++ b/bsg_dataflow/bsg_two_buncher.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_two_buncher
     parameters: 
       - width_p=2

--- a/bsg_dataflow/bsg_two_fifo.core
+++ b/bsg_dataflow/bsg_two_fifo.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_two_fifo
     parameters: 

--- a/bsg_fsb/bsg_front_side_bus_hop_in.core
+++ b/bsg_fsb/bsg_front_side_bus_hop_in.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_front_side_bus_hop_in
     parameters:

--- a/bsg_fsb/bsg_front_side_bus_hop_in_no_fc.core
+++ b/bsg_fsb/bsg_front_side_bus_hop_in_no_fc.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_front_side_bus_hop_in_no_fc
     parameters:
       - width_p=2

--- a/bsg_fsb/bsg_front_side_bus_hop_out.core
+++ b/bsg_fsb/bsg_front_side_bus_hop_out.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_front_side_bus_hop_out
     parameters:

--- a/bsg_fsb/bsg_fsb.core
+++ b/bsg_fsb/bsg_fsb.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN]
     toplevel: bsg_fsb
     parameters:

--- a/bsg_fsb/bsg_fsb_murn_gateway.core
+++ b/bsg_fsb/bsg_fsb_murn_gateway.core
@@ -21,6 +21,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN]
     toplevel: bsg_fsb_murn_gateway
     parameters:

--- a/bsg_fsb/bsg_fsb_node_async_buffer.core
+++ b/bsg_fsb/bsg_fsb_node_async_buffer.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_fsb_node_async_buffer
     parameters:

--- a/bsg_fsb/bsg_fsb_node_level_shift_fsb_domain.core
+++ b/bsg_fsb/bsg_fsb_node_level_shift_fsb_domain.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_fsb_node_level_shift_fsb_domain
     parameters:
       - ring_width_p=2

--- a/bsg_fsb/bsg_fsb_node_level_shift_node_domain.core
+++ b/bsg_fsb/bsg_fsb_node_level_shift_node_domain.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_fsb_node_level_shift_node_domain
     parameters:
       - ring_width_p=2

--- a/bsg_fsb/bsg_fsb_node_trace_replay.core
+++ b/bsg_fsb/bsg_fsb_node_trace_replay.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_fsb_node_trace_replay
 
 parameters:

--- a/bsg_fsb/bsg_nonsynth_fsb_node_trace_replay.core
+++ b/bsg_fsb/bsg_nonsynth_fsb_node_trace_replay.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_fsb_node_trace_replay
     parameters:
       - master_id_p=2

--- a/bsg_mem/bsg_cam_1r1w.core
+++ b/bsg_mem/bsg_cam_1r1w.core
@@ -26,6 +26,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT -Wno-WIDTH -Wno-PINMISSING]
     toplevel: bsg_cam_1r1w
     parameters: 

--- a/bsg_mem/bsg_cam_1r1w_replacement.core
+++ b/bsg_mem/bsg_cam_1r1w_replacement.core
@@ -28,6 +28,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT]
     toplevel: bsg_cam_1r1w_replacement
 

--- a/bsg_mem/bsg_cam_1r1w_sync.core
+++ b/bsg_mem/bsg_cam_1r1w_sync.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT -Wno-WIDTH -Wno-PINMISSING]
     toplevel: bsg_cam_1r1w_sync
     parameters: 

--- a/bsg_mem/bsg_cam_1r1w_sync_unmanaged.core
+++ b/bsg_mem/bsg_cam_1r1w_sync_unmanaged.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_cam_1r1w_sync_unmanaged
     parameters: 
       - tag_width_p=3

--- a/bsg_mem/bsg_cam_1r1w_tag_array.core
+++ b/bsg_mem/bsg_cam_1r1w_tag_array.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_cam_1r1w_tag_array
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_cam_1r1w_unmanaged.core
+++ b/bsg_mem/bsg_cam_1r1w_unmanaged.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_cam_1r1w_unmanaged
     parameters: 
       - tag_width_p=3

--- a/bsg_mem/bsg_mem_1r1w.core
+++ b/bsg_mem/bsg_mem_1r1w.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_1r1w
     parameters: 

--- a/bsg_mem/bsg_mem_1r1w_one_hot.core
+++ b/bsg_mem/bsg_mem_1r1w_one_hot.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_1r1w_one_hot
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_mem_1r1w_sync.core
+++ b/bsg_mem/bsg_mem_1r1w_sync.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_1r1w_sync
     parameters: 

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.core
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_1r1w_sync_mask_write_bit
     parameters: 

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.core
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_1r1w_sync_mask_write_bit_synth
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_mem_1r1w_sync_mask_write_var.core
+++ b/bsg_mem/bsg_mem_1r1w_sync_mask_write_var.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_1r1w_sync_mask_write_var
     parameters: 

--- a/bsg_mem/bsg_mem_1r1w_sync_synth.core
+++ b/bsg_mem/bsg_mem_1r1w_sync_synth.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_1r1w_sync_synth
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_mem_1r1w_synth.core
+++ b/bsg_mem/bsg_mem_1r1w_synth.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_1r1w_synth
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_mem_1rw_sync.core
+++ b/bsg_mem/bsg_mem_1rw_sync.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_1rw_sync
     parameters: 

--- a/bsg_mem/bsg_mem_1rw_sync_banked.core
+++ b/bsg_mem/bsg_mem_1rw_sync_banked.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-PINMISSING -Wno-WIDTH]
     toplevel: bsg_mem_1rw_sync_banked
     parameters: 

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.core
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_1rw_sync_mask_write_bit
     parameters: 

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.core
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-PINMISSING -Wno-WIDTH]
     toplevel: bsg_mem_1rw_sync_mask_write_bit_banked
     parameters: 

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.core
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_1rw_sync_mask_write_bit_synth
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.core
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_1rw_sync_mask_write_byte
     parameters: 
       - data_width_p=3

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.core
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_1rw_sync_mask_write_byte_banked
     parameters: 
       - data_width_p=4

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.core
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_1rw_sync_mask_write_byte_synth
     parameters: 
       - data_width_p=3

--- a/bsg_mem/bsg_mem_1rw_sync_mask_write_var.core
+++ b/bsg_mem/bsg_mem_1rw_sync_mask_write_var.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_1rw_sync_mask_write_var
     parameters: 

--- a/bsg_mem/bsg_mem_1rw_sync_synth.core
+++ b/bsg_mem/bsg_mem_1rw_sync_synth.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_1rw_sync_synth
     parameters: 

--- a/bsg_mem/bsg_mem_2r1w.core
+++ b/bsg_mem/bsg_mem_2r1w.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_2r1w
     parameters: 

--- a/bsg_mem/bsg_mem_2r1w_sync.core
+++ b/bsg_mem/bsg_mem_2r1w_sync.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_2r1w_sync
     parameters: 

--- a/bsg_mem/bsg_mem_2r1w_sync_synth.core
+++ b/bsg_mem/bsg_mem_2r1w_sync_synth.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_2r1w_sync_synth
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_mem_2r1w_synth.core
+++ b/bsg_mem/bsg_mem_2r1w_synth.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_2r1w_synth
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_mem_3r1w.core
+++ b/bsg_mem/bsg_mem_3r1w.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_3r1w
     parameters: 

--- a/bsg_mem/bsg_mem_3r1w_sync.core
+++ b/bsg_mem/bsg_mem_3r1w_sync.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_3r1w_sync
     parameters: 

--- a/bsg_mem/bsg_mem_3r1w_sync_synth.core
+++ b/bsg_mem/bsg_mem_3r1w_sync_synth.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_3r1w_sync_synth
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_mem_3r1w_synth.core
+++ b/bsg_mem/bsg_mem_3r1w_synth.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mem_3r1w_synth
     parameters: 
       - width_p=3

--- a/bsg_mem/bsg_mem_banked_crossbar_control_o_by_i.core
+++ b/bsg_mem/bsg_mem_banked_crossbar_control_o_by_i.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         # verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_banked_crossbar_control_o_by_i
     parameters: 

--- a/bsg_mem/bsg_mem_multiport.core
+++ b/bsg_mem/bsg_mem_multiport.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_mem_multiport
     parameters: 

--- a/bsg_mem/bsg_nonsynth_mem_1r1w_sync_dma.core
+++ b/bsg_mem/bsg_nonsynth_mem_1r1w_sync_dma.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN -Wno-SELRANGE -Wno-UNSIGNED]
     toplevel: bsg_nonsynth_mem_1r1w_sync_dma
     parameters: 

--- a/bsg_mem/bsg_nonsynth_mem_1r1w_sync_mask_write_byte_dma.core
+++ b/bsg_mem/bsg_nonsynth_mem_1r1w_sync_mask_write_byte_dma.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN -Wno-SELRANGE -Wno-UNSIGNED]
     toplevel: bsg_nonsynth_mem_1r1w_sync_mask_write_byte_dma
     parameters: 

--- a/bsg_mem/bsg_nonsynth_mem_1rw_sync_assoc.core
+++ b/bsg_mem/bsg_nonsynth_mem_1rw_sync_assoc.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         # verilator_options: [-Wno-WIDTH]
     toplevel: bsg_nonsynth_mem_1rw_sync_assoc
     parameters: 

--- a/bsg_mem/bsg_nonsynth_mem_1rw_sync_mask_write_byte_dma.core
+++ b/bsg_mem/bsg_nonsynth_mem_1rw_sync_mask_write_byte_dma.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN -Wno-SELRANGE -Wno-UNSIGNED]
     toplevel: bsg_nonsynth_mem_1rw_sync_mask_write_byte_dma
     parameters: 

--- a/bsg_misc/bsg_abs.core
+++ b/bsg_misc/bsg_abs.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_abs
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_adder_cin.core
+++ b/bsg_misc/bsg_adder_cin.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_adder_cin
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_adder_one_hot.core
+++ b/bsg_misc/bsg_adder_one_hot.core
@@ -30,6 +30,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_adder_one_hot
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_adder_ripple_carry.core
+++ b/bsg_misc/bsg_adder_ripple_carry.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_adder_ripple_carry
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_and.core
+++ b/bsg_misc/bsg_and.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_and
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_arb_fixed.core
+++ b/bsg_misc/bsg_arb_fixed.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT]
     toplevel: bsg_arb_fixed
     parameters: 

--- a/bsg_misc/bsg_arb_round_robin.core
+++ b/bsg_misc/bsg_arb_round_robin.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT]
     toplevel: bsg_arb_round_robin
     parameters: 

--- a/bsg_misc/bsg_array_concentrate_static.core
+++ b/bsg_misc/bsg_array_concentrate_static.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_array_concentrate_static
     parameters: 

--- a/bsg_misc/bsg_array_reverse.core
+++ b/bsg_misc/bsg_array_reverse.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_array_reverse
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_binary_plus_one_to_gray.core
+++ b/bsg_misc/bsg_binary_plus_one_to_gray.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT]
     toplevel: bsg_binary_plus_one_to_gray
     parameters: 

--- a/bsg_misc/bsg_buf.core
+++ b/bsg_misc/bsg_buf.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_buf
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_buf_ctrl.core
+++ b/bsg_misc/bsg_buf_ctrl.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_buf_ctrl
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_circular_ptr.core
+++ b/bsg_misc/bsg_circular_ptr.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_circular_ptr
     parameters: 
       - slots_p=2

--- a/bsg_misc/bsg_clkbuf.core
+++ b/bsg_misc/bsg_clkbuf.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_clkbuf
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_clkgate_optional.core
+++ b/bsg_misc/bsg_clkgate_optional.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_clkgate_optional
 
   verilator_tb:

--- a/bsg_misc/bsg_concentrate_static.core
+++ b/bsg_misc/bsg_concentrate_static.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_concentrate_static
     parameters: 

--- a/bsg_misc/bsg_counter_clear_up.core
+++ b/bsg_misc/bsg_counter_clear_up.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_counter_clear_up
     parameters: 

--- a/bsg_misc/bsg_counter_clear_up_one_hot.core
+++ b/bsg_misc/bsg_counter_clear_up_one_hot.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_counter_clear_up_one_hot
     parameters: 
       - max_val_p=2

--- a/bsg_misc/bsg_counter_clock_downsample.core
+++ b/bsg_misc/bsg_counter_clock_downsample.core
@@ -38,6 +38,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-WIDTHCONCAT]
     toplevel: bsg_counter_clock_downsample
     parameters: 

--- a/bsg_misc/bsg_counter_dynamic_limit.core
+++ b/bsg_misc/bsg_counter_dynamic_limit.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_counter_dynamic_limit
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_counter_dynamic_limit_en.core
+++ b/bsg_misc/bsg_counter_dynamic_limit_en.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_counter_dynamic_limit_en
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_counter_overflow_en.core
+++ b/bsg_misc/bsg_counter_overflow_en.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_counter_overflow_en
     parameters: 

--- a/bsg_misc/bsg_counter_overflow_set_en.core
+++ b/bsg_misc/bsg_counter_overflow_set_en.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_counter_overflow_set_en
     parameters: 

--- a/bsg_misc/bsg_counter_set_down.core
+++ b/bsg_misc/bsg_counter_set_down.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_counter_set_down
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_counter_set_en.core
+++ b/bsg_misc/bsg_counter_set_en.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_counter_set_en
     parameters: 
       - max_val_p=2

--- a/bsg_misc/bsg_counter_up_down.core
+++ b/bsg_misc/bsg_counter_up_down.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_counter_up_down
     parameters:

--- a/bsg_misc/bsg_counter_up_down_variable.core
+++ b/bsg_misc/bsg_counter_up_down_variable.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_counter_up_down_variable
     parameters:

--- a/bsg_misc/bsg_counting_leading_zeros.core
+++ b/bsg_misc/bsg_counting_leading_zeros.core
@@ -34,6 +34,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT]
     toplevel: bsg_counting_leading_zeros
     parameters: 

--- a/bsg_misc/bsg_crossbar_control_basic_o_by_i.core
+++ b/bsg_misc/bsg_crossbar_control_basic_o_by_i.core
@@ -35,6 +35,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT -Wno-WIDTH]
     toplevel: bsg_crossbar_control_basic_o_by_i
     parameters:

--- a/bsg_misc/bsg_crossbar_o_by_i.core
+++ b/bsg_misc/bsg_crossbar_o_by_i.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_crossbar_o_by_i
     parameters:
       - i_els_p=2

--- a/bsg_misc/bsg_cycle_counter.core
+++ b/bsg_misc/bsg_cycle_counter.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_cycle_counter
   
   verilator_tb:

--- a/bsg_misc/bsg_decode.core
+++ b/bsg_misc/bsg_decode.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_decode
     parameters: 

--- a/bsg_misc/bsg_decode_with_v.core
+++ b/bsg_misc/bsg_decode_with_v.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_decode_with_v
     parameters: 

--- a/bsg_misc/bsg_dff.core
+++ b/bsg_misc/bsg_dff.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dff_async_reset.core
+++ b/bsg_misc/bsg_dff_async_reset.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff_async_reset
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dff_chain.core
+++ b/bsg_misc/bsg_dff_chain.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff_chain
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dff_en.core
+++ b/bsg_misc/bsg_dff_en.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff_en
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dff_en_bypass.core
+++ b/bsg_misc/bsg_dff_en_bypass.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff_en_bypass
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dff_gatestack.core
+++ b/bsg_misc/bsg_dff_gatestack.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-MULTIDRIVEN]
     toplevel: bsg_dff_gatestack
     parameters: 

--- a/bsg_misc/bsg_dff_negedge_reset.core
+++ b/bsg_misc/bsg_dff_negedge_reset.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff_negedge_reset
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dff_reset.core
+++ b/bsg_misc/bsg_dff_reset.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff_reset
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dff_reset_en.core
+++ b/bsg_misc/bsg_dff_reset_en.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff_reset_en
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dff_reset_en_bypass.core
+++ b/bsg_misc/bsg_dff_reset_en_bypass.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff_reset_en_bypass
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dff_reset_set_clear.core
+++ b/bsg_misc/bsg_dff_reset_set_clear.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dff_reset_set_clear
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_dlatch.core
+++ b/bsg_misc/bsg_dlatch.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dlatch
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_edge_detect.core
+++ b/bsg_misc/bsg_edge_detect.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_edge_detect
     parameters: 
       - falling_not_rising_p=0

--- a/bsg_misc/bsg_encode_one_hot.core
+++ b/bsg_misc/bsg_encode_one_hot.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT]
     toplevel: bsg_encode_one_hot
     parameters: 

--- a/bsg_misc/bsg_expand_bitmask.core
+++ b/bsg_misc/bsg_expand_bitmask.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_expand_bitmask
     parameters: 
       - in_width_p=2

--- a/bsg_misc/bsg_gray_to_binary.core
+++ b/bsg_misc/bsg_gray_to_binary.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT]
     toplevel: bsg_gray_to_binary
     parameters: 

--- a/bsg_misc/bsg_hash_bank.core
+++ b/bsg_misc/bsg_hash_bank.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_hash_bank
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_hash_bank_reverse.core
+++ b/bsg_misc/bsg_hash_bank_reverse.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_hash_bank_reverse
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_id_pool.core
+++ b/bsg_misc/bsg_id_pool.core
@@ -34,6 +34,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT -Wno-WIDTH]
     toplevel: bsg_id_pool
     parameters: 

--- a/bsg_misc/bsg_idiv_iterative.core
+++ b/bsg_misc/bsg_idiv_iterative.core
@@ -37,6 +37,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-CASEINCOMPLETE -Wno-PINMISSING]
     toplevel: bsg_idiv_iterative
 

--- a/bsg_misc/bsg_idiv_iterative_controller.core
+++ b/bsg_misc/bsg_idiv_iterative_controller.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-CASEINCOMPLETE]
     toplevel: bsg_idiv_iterative_controller
 

--- a/bsg_misc/bsg_inv.core
+++ b/bsg_misc/bsg_inv.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_inv
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_less_than.core
+++ b/bsg_misc/bsg_less_than.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_less_than
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_level_shift_up_down_sink.core
+++ b/bsg_misc/bsg_level_shift_up_down_sink.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_level_shift_up_down_sink
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_level_shift_up_down_source.core
+++ b/bsg_misc/bsg_level_shift_up_down_source.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_level_shift_up_down_source
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_lfsr.core
+++ b/bsg_misc/bsg_lfsr.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_lfsr
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_locking_arb_fixed.core
+++ b/bsg_misc/bsg_locking_arb_fixed.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT]
     toplevel: bsg_locking_arb_fixed
     parameters: 

--- a/bsg_misc/bsg_lru_pseudo_tree_backup.core
+++ b/bsg_misc/bsg_lru_pseudo_tree_backup.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_lru_pseudo_tree_backup
     parameters: 
       - ways_p=2

--- a/bsg_misc/bsg_lru_pseudo_tree_decode.core
+++ b/bsg_misc/bsg_lru_pseudo_tree_decode.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_lru_pseudo_tree_decode
     parameters: 
       - ways_p=2

--- a/bsg_misc/bsg_lru_pseudo_tree_encode.core
+++ b/bsg_misc/bsg_lru_pseudo_tree_encode.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_lru_pseudo_tree_encode
     parameters: 
       - ways_p=2

--- a/bsg_misc/bsg_mux.core
+++ b/bsg_misc/bsg_mux.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mux
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_mux2_gatestack.core
+++ b/bsg_misc/bsg_mux2_gatestack.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mux2_gatestack
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_mux_bitwise.core
+++ b/bsg_misc/bsg_mux_bitwise.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mux_bitwise
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_mux_butterfly.core
+++ b/bsg_misc/bsg_mux_butterfly.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT]
     toplevel: bsg_mux_butterfly
     parameters: 

--- a/bsg_misc/bsg_mux_one_hot.core
+++ b/bsg_misc/bsg_mux_one_hot.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mux_one_hot
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_mux_segmented.core
+++ b/bsg_misc/bsg_mux_segmented.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mux_segmented
     parameters: 
       - segments_p=2

--- a/bsg_misc/bsg_muxi2_gatestack.core
+++ b/bsg_misc/bsg_muxi2_gatestack.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_muxi2_gatestack
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_nand.core
+++ b/bsg_misc/bsg_nand.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nand
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_nor2.core
+++ b/bsg_misc/bsg_nor2.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nor2
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_nor3.core
+++ b/bsg_misc/bsg_nor3.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nor3
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_pg_tree.core
+++ b/bsg_misc/bsg_pg_tree.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_pg_tree
     parameters: 
       - input_width_p=2

--- a/bsg_misc/bsg_popcount.core
+++ b/bsg_misc/bsg_popcount.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_popcount
     parameters: 
       - width_p=4

--- a/bsg_misc/bsg_priority_encode.core
+++ b/bsg_misc/bsg_priority_encode.core
@@ -32,6 +32,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT -Wno-WIDTH]
     toplevel: bsg_priority_encode
     parameters: 

--- a/bsg_misc/bsg_priority_encode_one_hot_out.core
+++ b/bsg_misc/bsg_priority_encode_one_hot_out.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-UNOPTFLAT -Wno-WIDTH]
     toplevel: bsg_priority_encode_one_hot_out
     parameters: 

--- a/bsg_misc/bsg_reduce.core
+++ b/bsg_misc/bsg_reduce.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTHCONCAT -Wno-WIDTH]
     toplevel: bsg_reduce
     parameters: 

--- a/bsg_misc/bsg_reduce_segmented.core
+++ b/bsg_misc/bsg_reduce_segmented.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_reduce_segmented
     parameters: 

--- a/bsg_misc/bsg_rotate_left.core
+++ b/bsg_misc/bsg_rotate_left.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_rotate_left
     parameters: 

--- a/bsg_misc/bsg_rotate_right.core
+++ b/bsg_misc/bsg_rotate_right.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_rotate_right
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_round_robin_arb.core
+++ b/bsg_misc/bsg_round_robin_arb.core
@@ -33,6 +33,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_round_robin_arb
     parameters: 

--- a/bsg_misc/bsg_scan.core
+++ b/bsg_misc/bsg_scan.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT]
     toplevel: bsg_scan
     parameters: 

--- a/bsg_misc/bsg_strobe.core
+++ b/bsg_misc/bsg_strobe.core
@@ -37,6 +37,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-WIDTHCONCAT]
     toplevel: bsg_strobe
     parameters: 

--- a/bsg_misc/bsg_swap.core
+++ b/bsg_misc/bsg_swap.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_swap
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_thermometer_count.core
+++ b/bsg_misc/bsg_thermometer_count.core
@@ -31,6 +31,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_thermometer_count
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_tiehi.core
+++ b/bsg_misc/bsg_tiehi.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_tiehi
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_tielo.core
+++ b/bsg_misc/bsg_tielo.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_tielo
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_transpose.core
+++ b/bsg_misc/bsg_transpose.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_transpose
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_unconcentrate_static.core
+++ b/bsg_misc/bsg_unconcentrate_static.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_unconcentrate_static
     parameters: 

--- a/bsg_misc/bsg_wait_after_reset.core
+++ b/bsg_misc/bsg_wait_after_reset.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_wait_after_reset
     parameters: 
       - lg_wait_cycles_p=3

--- a/bsg_misc/bsg_wait_cycles.core
+++ b/bsg_misc/bsg_wait_cycles.core
@@ -30,6 +30,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_wait_cycles
     parameters: 

--- a/bsg_misc/bsg_xnor.core
+++ b/bsg_misc/bsg_xnor.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_xnor
     parameters: 
       - width_p=2

--- a/bsg_misc/bsg_xor.core
+++ b/bsg_misc/bsg_xor.core
@@ -29,6 +29,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_xor
     parameters: 
       - width_p=2

--- a/bsg_noc/bsg_barrier.core
+++ b/bsg_noc/bsg_barrier.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_barrier
     parameters:
       - dirs_p=2

--- a/bsg_noc/bsg_mesh_router.core
+++ b/bsg_noc/bsg_mesh_router.core
@@ -30,6 +30,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT -Wno-SELRANGE]
     toplevel: bsg_mesh_router
     parameters:

--- a/bsg_noc/bsg_mesh_router_buffered.core
+++ b/bsg_noc/bsg_mesh_router_buffered.core
@@ -27,6 +27,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT -Wno-SELRANGE]
     toplevel: bsg_mesh_router_buffered
     parameters:

--- a/bsg_noc/bsg_mesh_router_decoder_dor.core
+++ b/bsg_noc/bsg_mesh_router_decoder_dor.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mesh_router_decoder_dor
     parameters:
       - x_cord_width_p=2

--- a/bsg_noc/bsg_mesh_router_pkg.core
+++ b/bsg_noc/bsg_mesh_router_pkg.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mesh_router_pkg
 
 provider :

--- a/bsg_noc/bsg_mesh_stitch.core
+++ b/bsg_noc/bsg_mesh_stitch.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mesh_stitch
     parameters:
       - width_p=2

--- a/bsg_noc/bsg_mesh_to_ring_stitch.core
+++ b/bsg_noc/bsg_mesh_to_ring_stitch.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_mesh_to_ring_stitch
     parameters:
       - y_max_p=2

--- a/bsg_noc/bsg_noc_pkg.core
+++ b/bsg_noc/bsg_noc_pkg.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_noc_pkg
 
 provider :

--- a/bsg_noc/bsg_noc_repeater_node.core
+++ b/bsg_noc/bsg_noc_repeater_node.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_noc_repeater_node
     parameters:

--- a/bsg_noc/bsg_ready_and_link_async_to_wormhole.core
+++ b/bsg_noc/bsg_ready_and_link_async_to_wormhole.core
@@ -26,6 +26,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_ready_and_link_async_to_wormhole
     parameters:

--- a/bsg_noc/bsg_router_crossbar_o_by_i.core
+++ b/bsg_noc/bsg_router_crossbar_o_by_i.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-UNOPTFLAT]
     toplevel: bsg_router_crossbar_o_by_i
     parameters:

--- a/bsg_noc/bsg_wormhole_concentrator.core
+++ b/bsg_noc/bsg_wormhole_concentrator.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_wormhole_concentrator__abstract
 
 parameters:

--- a/bsg_noc/bsg_wormhole_concentrator_in.core
+++ b/bsg_noc/bsg_wormhole_concentrator_in.core
@@ -27,6 +27,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_wormhole_concentrator_in__abstract
 
 parameters:

--- a/bsg_noc/bsg_wormhole_concentrator_out.core
+++ b/bsg_noc/bsg_wormhole_concentrator_out.core
@@ -27,6 +27,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_wormhole_concentrator_out__abstract
 
 parameters:

--- a/bsg_noc/bsg_wormhole_router.core
+++ b/bsg_noc/bsg_wormhole_router.core
@@ -34,6 +34,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_wormhole_router__abstract
 
 parameters:

--- a/bsg_noc/bsg_wormhole_router_adapter.core
+++ b/bsg_noc/bsg_wormhole_router_adapter.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-CMPCONST]
     toplevel: bsg_wormhole_router_adapter
     parameters:

--- a/bsg_noc/bsg_wormhole_router_adapter_in.core
+++ b/bsg_noc/bsg_wormhole_router_adapter_in.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-CMPCONST]
     toplevel: bsg_wormhole_router_adapter_in
     parameters:

--- a/bsg_noc/bsg_wormhole_router_adapter_out.core
+++ b/bsg_noc/bsg_wormhole_router_adapter_out.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_wormhole_router_adapter_out
     parameters:

--- a/bsg_noc/bsg_wormhole_router_decoder_dor.core
+++ b/bsg_noc/bsg_wormhole_router_decoder_dor.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_wormhole_router_decoder_dor
     parameters:
       - dims_p=2

--- a/bsg_noc/bsg_wormhole_router_input_control.core
+++ b/bsg_noc/bsg_wormhole_router_input_control.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_wormhole_router_input_control__abstract
 
 provider :

--- a/bsg_noc/bsg_wormhole_router_output_control.core
+++ b/bsg_noc/bsg_wormhole_router_output_control.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_wormhole_router_output_control
     parameters:

--- a/bsg_tag/bsg_tag_client.core
+++ b/bsg_tag/bsg_tag_client.core
@@ -26,6 +26,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_tag_client
     parameters: 
       - width_p=2

--- a/bsg_tag/bsg_tag_client_unsync.core
+++ b/bsg_tag/bsg_tag_client_unsync.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_tag_client_unsync
     parameters: 
       - width_p=2

--- a/bsg_tag/bsg_tag_master.core
+++ b/bsg_tag/bsg_tag_master.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_tag_master
     parameters: 

--- a/bsg_tag/bsg_tag_master_decentralized.core
+++ b/bsg_tag/bsg_tag_master_decentralized.core
@@ -24,6 +24,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_tag_master_decentralized
     parameters: 

--- a/bsg_tag/bsg_tag_trace_replay.core
+++ b/bsg_tag/bsg_tag_trace_replay.core
@@ -25,6 +25,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-PINMISSING -Wno-SELRANGE]
     toplevel: bsg_tag_trace_replay
     parameters: 

--- a/bsg_test/bsg_dramsim3_pkg.core
+++ b/bsg_test/bsg_dramsim3_pkg.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_dramsim3_pkg
 
 provider :

--- a/bsg_test/bsg_nonsynth_ascii_writer.core
+++ b/bsg_test/bsg_nonsynth_ascii_writer.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_ascii_writer
     parameters:
       - width_p=2

--- a/bsg_test/bsg_nonsynth_axi_mem.core
+++ b/bsg_test/bsg_nonsynth_axi_mem.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_axi_mem
     parameters:
       - axi_id_width_p=2

--- a/bsg_test/bsg_nonsynth_clock_gen.core
+++ b/bsg_test/bsg_nonsynth_clock_gen.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_clock_gen
     parameters:
       - cycle_time_p=2

--- a/bsg_test/bsg_nonsynth_clock_gen_plusarg.core
+++ b/bsg_test/bsg_nonsynth_clock_gen_plusarg.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_clock_gen_plusarg
     parameters:
       - default_clk_per_p=2

--- a/bsg_test/bsg_nonsynth_delay_line.core
+++ b/bsg_test/bsg_nonsynth_delay_line.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-COMBDLY]
     toplevel: bsg_nonsynth_delay_line
     parameters:

--- a/bsg_test/bsg_nonsynth_dpi_clock_gen.core
+++ b/bsg_test/bsg_nonsynth_dpi_clock_gen.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_nonsynth_dpi_clock_gen
     parameters: 

--- a/bsg_test/bsg_nonsynth_dpi_cycle_counter.core
+++ b/bsg_test/bsg_nonsynth_dpi_cycle_counter.core
@@ -23,6 +23,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_nonsynth_dpi_cycle_counter
     parameters: 

--- a/bsg_test/bsg_nonsynth_dpi_from_fifo.core
+++ b/bsg_test/bsg_nonsynth_dpi_from_fifo.core
@@ -21,6 +21,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_dpi_from_fifo
     parameters:
       - width_p=8

--- a/bsg_test/bsg_nonsynth_dpi_gpio.core
+++ b/bsg_test/bsg_nonsynth_dpi_gpio.core
@@ -21,6 +21,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_nonsynth_dpi_gpio
     parameters:

--- a/bsg_test/bsg_nonsynth_dpi_rom.core
+++ b/bsg_test/bsg_nonsynth_dpi_rom.core
@@ -21,6 +21,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_dpi_rom
     parameters: 
       - els_p=2

--- a/bsg_test/bsg_nonsynth_dpi_to_fifo.core
+++ b/bsg_test/bsg_nonsynth_dpi_to_fifo.core
@@ -21,6 +21,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-MULTIDRIVEN]
     toplevel: bsg_nonsynth_dpi_to_fifo
     parameters:

--- a/bsg_test/bsg_nonsynth_dramsim3.core
+++ b/bsg_test/bsg_nonsynth_dramsim3.core
@@ -27,6 +27,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_nonsynth_dramsim3
     parameters:

--- a/bsg_test/bsg_nonsynth_dramsim3_map.core
+++ b/bsg_test/bsg_nonsynth_dramsim3_map.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN]
     toplevel: bsg_nonsynth_dramsim3_map
     parameters:

--- a/bsg_test/bsg_nonsynth_dramsim3_unmap.core
+++ b/bsg_test/bsg_nonsynth_dramsim3_unmap.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH -Wno-LITENDIAN]
     toplevel: bsg_nonsynth_dramsim3_unmap
     parameters:

--- a/bsg_test/bsg_nonsynth_ramulator_hbm.core
+++ b/bsg_test/bsg_nonsynth_ramulator_hbm.core
@@ -22,6 +22,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         # verilator_options: [-Wno-WIDTH]
     toplevel: bsg_nonsynth_ramulator_hbm
     parameters:

--- a/bsg_test/bsg_nonsynth_random_gen.core
+++ b/bsg_test/bsg_nonsynth_random_gen.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_nonsynth_random_gen
 

--- a/bsg_test/bsg_nonsynth_reset_gen.core
+++ b/bsg_test/bsg_nonsynth_reset_gen.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: bsg_nonsynth_reset_gen
     parameters: 

--- a/bsg_test/bsg_nonsynth_test_rom.core
+++ b/bsg_test/bsg_nonsynth_test_rom.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_test_rom
     parameters:
       - data_width_p=4

--- a/bsg_test/bsg_nonsynth_triwire.core
+++ b/bsg_test/bsg_nonsynth_triwire.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_triwire
     parameters:
       - width_p=4

--- a/bsg_test/bsg_nonsynth_val_watcher_1p.core
+++ b/bsg_test/bsg_nonsynth_val_watcher_1p.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_nonsynth_val_watcher_1p
     parameters:
       - trigger_val_p=2

--- a/bsg_test/bsg_trace_replay.core
+++ b/bsg_test/bsg_trace_replay.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
     toplevel: bsg_trace_replay
 
 parameters:

--- a/bsg_test/test_bsg_data_gen.core
+++ b/bsg_test/test_bsg_data_gen.core
@@ -20,6 +20,7 @@ targets:
     tools:
       verilator: 
         mode: lint-only
+        verilator_options: [-Wwarn-lint -Wwarn-style]
         verilator_options: [-Wno-WIDTH]
     toplevel: test_bsg_data_gen
     parameters:


### PR DESCRIPTION
This prints out more warnings when running a lint target, useful for continuous integration to monitor violations