### PR TITLE
Add a large core for BlackParrot

### DIFF
--- a/bsg_blackparrot.core
+++ b/bsg_blackparrot.core
@@ -1,0 +1,472 @@
+CAPI=2:
+
+name: ::bsg_black_parrot:0-r1
+description: Includes all Basejump RTL for BlackParrot
+
+filesets:
+  rtl:
+    files:
+      - bsg_tag/bsg_tag.vh: {is_include_file: true}
+      - bsg_comm_link/bsg_comm_link.vh: {is_include_file: true}
+      - bsg_dmc/bsg_dmc.vh: {is_include_file: true}
+      - bsg_fpu/bsg_fpu_defines.vh: {is_include_file: true}
+      # - hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh: {is_include_file: true}
+      # - hard/gf_14/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh: {is_include_file: true}
+      # - hard/gf_14/bsg_mem/bsg_mem_3r1w_sync_macros.vh: {is_include_file: true}
+      # - hard/gf_14/bsg_mem/bsg_mem_2r1w_sync_macros.vh: {is_include_file: true}
+      # - hard/gf_14/bsg_mem/bsg_mem_1rw_sync_macros.vh: {is_include_file: true}
+      # - hard/gf_14/bsg_mem/bsg_mem_1r1w_sync_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_3r1w_sync_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_macros.vh: {is_include_file: true}
+      # - hard/tsmc_28/bsg_mem/bsg_mem_2r1w_sync_macros.vh: {is_include_file: true}
+      # - hard/fakeram/bsg_mem_1rw_sync_mask_write_bit_macros.vh: {is_include_file: true}
+      # - hard/fakeram/bsg_mem_1rw_sync_mask_write_byte_macros.vh: {is_include_file: true}
+      # - hard/fakeram/bsg_mem_1rw_sync_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_1r1w_sync_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_2rw_sync_mask_write_bit_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_2rw_sync_mask_write_byte_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_3r1w_sync_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_2rw_sync_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_1rw_sync_macros.vh: {is_include_file: true}
+      - hard/generic/bsg_mem/bsg_mem_2r1w_sync_macros.vh: {is_include_file: true}
+      - testing/bsg_dmc/lpddr_verilog_model/256Mb_mobile_ddr_parameters.vh: {is_include_file: true}
+      - testing/bsg_dmc/lpddr_verilog_model/128Mb_mobile_ddr_parameters.vh: {is_include_file: true}
+      - testing/bsg_dmc/lpddr_verilog_model/512Mb_mobile_ddr_parameters.vh: {is_include_file: true}
+      - testing/bsg_dmc/lpddr_verilog_model/1024Mb_mobile_ddr_parameters.vh: {is_include_file: true}
+      - testing/bsg_dmc/lpddr_verilog_model/2048Mb_mobile_ddr_parameters.vh: {is_include_file: true}
+      - testing/bsg_dmc/lpddr_verilog_model/subtest.vh: {is_include_file: true}
+      - bsg_cache/bsg_cache_non_blocking.vh: {is_include_file: true}
+      - bsg_cache/bsg_cache.vh: {is_include_file: true}
+      # - bsg_test/bsg_dramsim3.vh: {is_include_file: true}
+      # - bsg_test/bsg_nonsynth_dramsim3.svh: {is_include_file: true}
+      - bsg_clk_gen/bsg_clk_gen.vh: {is_include_file: true}
+      - bsg_noc/bsg_wormhole_router.vh: {is_include_file: true}
+      - bsg_noc/bsg_noc_links.vh: {is_include_file: true}
+      - bsg_test/test_assembler_defines.v: {is_include_file: true}
+      - bsg_misc/bsg_defines.v: {is_include_file: true}
+      # - bsg_tag/legacy/config_net/src/config_defs.v: {is_include_file: true}
+      # - bsg_tag/legacy/config_net/tests/cfgtaggw_test/config_defs.v: {is_include_file: true}
+      - bsg_mesosync_io/src/config_defs.v: {is_include_file: true}
+      # - bsg_tag/legacy/config_net/src/config_utils.v: {is_include_file: true}
+      - bsg_fsb/bsg_fsb_pkg.v: {is_include_file: true}
+      # - bsg_test/test_bsg_clock_params.v: {is_include_file: true}
+
+      - bsg_tag/bsg_tag_pkg.v
+      - bsg_riscv/bsg_nasti/bsg_nasti_pkg.v
+      # - bsg_riscv/bsg_hasti/bsg_vscale_pkg.v
+      - bsg_cache/bsg_cache_non_blocking_pkg.v
+      - bsg_cache/bsg_cache_pkg.v
+      - bsg_link/bsg_link_pkg.v
+      # - bsg_test/bsg_dramsim3_pkg.v
+      - bsg_dmc/bsg_dmc_pkg.v
+      - bsg_noc/bsg_noc_pkg.v
+      - bsg_noc/bsg_mesh_router_pkg.v
+      - bsg_noc/bsg_wormhole_router_pkg.v
+
+      - bsg_dataflow/bsg_round_robin_2_to_2.v
+      - bsg_dataflow/bsg_fifo_1r1w_pseudo_large.v
+      - bsg_dataflow/bsg_channel_tunnel.v
+      - bsg_dataflow/bsg_fifo_1r1w_large_banked.v
+      - bsg_dataflow/bsg_parallel_in_serial_out_passthrough.v
+      - bsg_dataflow/bsg_fifo_1r1w_small_unhardened.v
+      - bsg_dataflow/bsg_fifo_1r1w_narrowed.v
+      - bsg_dataflow/bsg_two_fifo.v
+      - bsg_dataflow/bsg_8b10b_decode_comb.v
+      - bsg_dataflow/bsg_fifo_1r1w_small.v
+      - bsg_dataflow/bsg_make_2D_array.v
+      - bsg_dataflow/bsg_flatten_2D_array.v
+      - bsg_dataflow/bsg_relay_fifo.v
+      - bsg_dataflow/bsg_sbox.v
+      - bsg_dataflow/bsg_1_to_n_tagged_fifo.v
+      - bsg_dataflow/bsg_sort_stable.v
+      - bsg_dataflow/bsg_fifo_1rw_large.v
+      - bsg_dataflow/bsg_round_robin_n_to_1.v
+      - bsg_dataflow/bsg_one_fifo.v
+      - bsg_dataflow/bsg_flow_counter.v
+      - bsg_dataflow/bsg_parallel_in_serial_out.v
+      - bsg_dataflow/bsg_round_robin_1_to_n.v
+      - bsg_dataflow/bsg_fifo_1r1w_small_hardened.v
+      - bsg_dataflow/bsg_compare_and_swap.v
+      - bsg_dataflow/bsg_1_to_n_tagged_fifo_shared.v
+      - bsg_dataflow/bsg_parallel_in_serial_out_dynamic.v
+      - bsg_dataflow/bsg_fifo_bypass.v
+      - bsg_dataflow/bsg_8b10b_shift_decoder.v
+      - bsg_dataflow/bsg_fifo_1r1w_large.v
+      - bsg_dataflow/bsg_channel_tunnel_in.v
+      - bsg_dataflow/bsg_8b10b_encode_comb.v
+      - bsg_dataflow/bsg_fifo_shift_datapath.v
+      - bsg_dataflow/bsg_flow_convert.v
+      - bsg_dataflow/bsg_channel_tunnel_out.v
+      - bsg_dataflow/bsg_permute_box.v
+      - bsg_dataflow/bsg_round_robin_fifo_to_fifo.v
+      - bsg_dataflow/bsg_fifo_reorder.v
+      - bsg_dataflow/bsg_serial_in_parallel_out_passthrough.v
+      - bsg_dataflow/bsg_sort_4.v
+      - bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v
+      - bsg_dataflow/bsg_fifo_1r1w_small_credit_on_input.v
+      - bsg_dataflow/bsg_1_to_n_tagged.v
+      - bsg_dataflow/bsg_channel_narrow.v
+      - bsg_dataflow/bsg_serial_in_parallel_out_full.v
+      - bsg_dataflow/bsg_channel_tunnel_wormhole.v
+      - bsg_dataflow/bsg_shift_reg.v
+      - bsg_dataflow/bsg_serial_in_parallel_out.v
+      - bsg_dataflow/bsg_scatter_gather.v
+      - bsg_dataflow/bsg_credit_to_token.v
+      - bsg_dataflow/bsg_two_buncher.v
+      - bsg_dataflow/bsg_fifo_tracker.v
+      - bsg_dataflow/bsg_ready_to_credit_flow_converter.v
+      - bsg_tag/bsg_tag_master_decentralized.v
+      - bsg_tag/bsg_tag_trace_replay.v
+      - bsg_tag/bsg_tag_master.v
+      - bsg_tag/bsg_tag_client_unsync.v
+      - bsg_tag/bsg_tag_client.v
+      # - bsg_tag/legacy/config_net/src/config_snooper.v
+      # - bsg_tag/legacy/config_net/src/config_node.v
+      # - bsg_tag/legacy/config_net/src/relay_node.v
+      # - bsg_tag/legacy/config_net/src/cfgtaggw.v
+      # - bsg_tag/legacy/config_net/src/rNandMeta.v
+      # - bsg_tag/legacy/config_net/sim/send_config_tag.v
+      # - bsg_tag/legacy/config_net/sim/config_file_setter.v
+      # - bsg_tag/legacy/config_net/sim/config_node_bind.v
+      # - bsg_tag/legacy/config_net/sim/config_snooper_bind.v
+      # - bsg_tag/legacy/config_net/sim/config_setter.v
+      # - bsg_tag/legacy/config_net/tests/cfgtaggw_test/cfg_tag_tb.v
+      # - bsg_tag/legacy/config_net/tests/cfgtaggw_test/cfgtag.v
+      # - bsg_fsb/bsg_front_side_bus_hop_in_no_fc.v
+      # - bsg_fsb/bsg_front_side_bus_hop_out.v
+      # - bsg_fsb/bsg_fsb.v
+      # - bsg_fsb/bsg_front_side_bus_hop_in.v
+      # - bsg_fsb/bsg_fsb_node_trace_replay.v
+      # - bsg_fsb/bsg_fsb_murn_gateway.v
+      - bsg_fsb/bsg_nonsynth_fsb_node_trace_replay.v
+      # - bsg_fsb/bsg_fsb_node_async_buffer.v
+      # - bsg_fsb/bsg_fsb_node_level_shift_fsb_domain.v
+      # - bsg_fsb/bsg_fsb_node_level_shift_node_domain.v
+      - bsg_fpu/bsg_fpu_i2f.v
+      - bsg_fpu/bsg_fpu_cmp.v
+      - bsg_fpu/bsg_fpu_add_sub.v
+      - bsg_fpu/bsg_fpu_f2i.v
+      - bsg_fpu/bsg_fpu_mul.v
+      - bsg_fpu/bsg_fpu_sticky.v
+      - bsg_fpu/bsg_fpu_clz.v
+      - bsg_fpu/bsg_fpu_preprocess.v
+      - bsg_fpu/bsg_fpu_classify.v
+      # - bsg_riscv/bsg_htif/bsg_fsb_to_htif_connector.v
+      # - bsg_riscv/bsg_nasti/bsg_fsb_to_nasti_master_connector.v
+      # - bsg_riscv/bsg_nasti/bsg_fsb_to_nasti_slave_connector.v
+      # - bsg_riscv/bsg_hasti/bsg_vscale_hasti_converter.v
+      - bsg_cache/bsg_cache_to_test_dram_tx.v
+      - bsg_cache/bsg_cache_non_blocking_dma.v
+      - bsg_cache/bsg_cache_dma.v
+      - bsg_cache/bsg_cache_non_blocking_tl_stage.v
+      - bsg_cache/bsg_wormhole_to_cache_dma_fanout.v
+      - bsg_cache/bsg_cache_dma_to_wormhole.v
+      - bsg_cache/bsg_cache_non_blocking_stat_mem.v
+      - bsg_cache/bsg_nonsynth_cache_axe_tracer.v
+      - bsg_cache/bsg_cache_sbuf_queue.v
+      - bsg_cache/bsg_cache_miss.v
+      - bsg_cache/bsg_cache_to_dram_ctrl_rx.v
+      - bsg_cache/bsg_cache_to_axi_tx.v
+      - bsg_cache/bsg_cache_non_blocking_data_mem.v
+      - bsg_cache/bsg_cache_to_axi.v
+      - bsg_cache/bsg_cache_to_test_dram_rx_reorder.v
+      - bsg_cache/bsg_cache_non_blocking_tag_mem.v
+      - bsg_cache/bsg_cache_to_dram_ctrl.v
+      - bsg_cache/bsg_cache_to_test_dram.v
+      - bsg_cache/bsg_cache_non_blocking.v
+      - bsg_cache/bsg_cache_sbuf.v
+      - bsg_cache/bsg_cache_to_axi_rx.v
+      - bsg_cache/bsg_cache_non_blocking_decode.v
+      - bsg_cache/bsg_cache_to_test_dram_rx.v
+      - bsg_cache/bsg_cache_decode.v
+      - bsg_cache/bsg_cache_non_blocking_miss_fifo.v
+      - bsg_cache/bsg_cache_non_blocking_mhu.v
+      - bsg_cache/bsg_cache.v
+      - bsg_cache/bsg_cache_to_dram_ctrl_tx.v
+      - bsg_link/bsg_link_source_sync_upstream.v
+      - bsg_link/bsg_link_sdr.v
+      - bsg_link/bsg_link_iddr_phy.v
+      - bsg_link/bsg_link_ddr_downstream.v
+      - bsg_link/bsg_link_osdr_phy.v
+      - bsg_link/bsg_link_ddr_upstream.v
+      - bsg_link/bsg_link_sdr_downstream.v
+      - bsg_link/bsg_link_oddr_phy.v
+      - bsg_link/bsg_link_sdr_upstream.v
+      - bsg_link/bsg_link_source_sync_downstream.v
+      - bsg_link/bsg_link_source_sync_upstream_sync.v
+      - bsg_link/bsg_link_isdr_phy.v
+      - bsg_link/bsg_link_osdr_phy_phase_align.v
+      - bsg_math/bsg_hypotenuse/bsg_hypotenuse.v
+      - bsg_math/bsg_hypotenuse/test_bsg_hypotenuse.v
+      - bsg_mem/bsg_mem_1r1w_sync_mask_write_var.v
+      - bsg_mem/bsg_mem_3r1w_synth.v
+      - bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v
+      - bsg_mem/bsg_mem_2rw_sync_mask_write_bit.v
+      - bsg_mem/bsg_mem_2r1w.v
+      # - bsg_mem/bsg_nonsynth_mem_1rw_sync_assoc.v
+      - bsg_mem/bsg_cam_1r1w_tag_array.v
+      - bsg_mem/bsg_mem_2rw_sync_mask_write_bit_synth.v
+      - bsg_mem/bsg_mem_2r1w_sync.v
+      - bsg_mem/bsg_mem_multiport_latch_write_banked_bypassing.v
+      - bsg_mem/bsg_mem_1r1w_sync_synth.v
+      - bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+      - bsg_mem/bsg_mem_1r1w_sync.v
+      - bsg_mem/bsg_cam_1r1w_sync.v
+      - bsg_mem/bsg_mem_2r1w_synth.v
+      - bsg_mem/bsg_mem_1r1w_synth.v
+      - bsg_mem/bsg_mem_banked_crossbar.v
+      - bsg_mem/bsg_cam_1r1w_unmanaged.v
+      - bsg_mem/bsg_mem_1r1w_sync_mask_write_bit.v
+      - bsg_mem/bsg_nonsynth_mem_1rw_sync_mask_write_byte_assoc.v
+      - bsg_mem/bsg_mem_1rw_sync_synth.v
+      - bsg_mem/bsg_mem_1rw_sync_mask_write_bit_from_1r1w.v
+      - bsg_mem/bsg_cam_1r1w_sync_unmanaged.v
+      - bsg_mem/bsg_mem_3r1w_sync_synth.v
+      - bsg_mem/bsg_mem_2rw_sync_mask_write_byte_synth.v
+      - bsg_mem/bsg_mem_3r1w.v
+      - bsg_mem/bsg_mem_2rw_sync_synth.v
+      - bsg_mem/bsg_mem_2rw_sync.v
+      - bsg_mem/bsg_mem_3r1w_sync.v
+      - bsg_mem/bsg_mem_multiport_latch.v
+      - bsg_mem/bsg_mem_multiport.v
+      - bsg_mem/bsg_mem_1r1w.v
+      - bsg_mem/bsg_mem_2r1w_sync_synth.v
+      - bsg_mem/bsg_mem_1rw_sync_mask_write_bit_banked.v
+      - bsg_mem/bsg_mem_1r1w_sync_mask_write_byte.v
+      - bsg_mem/bsg_mem_1rw_sync_mask_write_var.v
+      - bsg_mem/bsg_mem_1rw_sync_banked.v
+      - bsg_mem/bsg_mem_1r1w_sync_mask_write_bit_synth.v
+      - bsg_mem/bsg_mem_1rw_sync_mask_write_byte_banked.v
+      - bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+      - bsg_mem/bsg_mem_1rw_sync.v
+      - bsg_mem/bsg_mem_1r1w_one_hot.v
+      - bsg_mem/bsg_cam_1r1w.v
+      - bsg_mem/bsg_cam_1r1w_replacement.v
+      - bsg_mem/bsg_mem_1r1w_sync_mask_write_byte_synth.v
+      - bsg_mem/bsg_nonsynth_mem_1r1w_sync_mask_write_byte_dma.v
+      - bsg_mem/bsg_nonsynth_mem_1r1w_sync_dma.v
+      - bsg_mem/bsg_mem_multiport_latch_write_banked_bypassing_sync.v
+      - bsg_mem/bsg_mem_1r1w_sync_banked.v
+      - bsg_mem/bsg_nonsynth_mem_1rw_sync_mask_write_byte_dma.v
+      - bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
+      - bsg_mem/bsg_mem_2rw_sync_mask_write_byte.v
+      - bsg_test/bsg_nonsynth_delay_line.v
+      - bsg_test/bsg_nonsynth_dpi_to_fifo.v
+      - bsg_test/bsg_nonsynth_clock_gen_plusarg.v
+      # - bsg_test/bsg_nonsynth_dramsim3_map.v
+      - bsg_test/bsg_trace_replay.v
+      # - bsg_test/test_bsg_data_gen.v
+      - bsg_test/bsg_nonsynth_axi_mem.v
+      - bsg_test/bsg_nonsynth_test_rom.v
+      # - bsg_test/bsg_nonsynth_triwire.v
+      # - bsg_test/bsg_nonsynth_dpi_rom.v
+      # - bsg_test/bsg_nonsynth_reset_gen.v
+      # - bsg_test/bsg_nonsynth_random_gen.v
+      # - bsg_test/bsg_nonsynth_ramulator_hbm.v
+      # - bsg_test/bsg_nonsynth_dpi_gpio.v
+      # - bsg_test/bsg_nonsynth_clock_gen.v
+      # - bsg_test/bsg_nonsynth_dramsim3_unmap.v
+      # - bsg_test/bsg_nonsynth_val_watcher_1p.v
+      # - bsg_test/bsg_nonsynth_dpi_cycle_counter.v
+      # - bsg_test/bsg_nonsynth_dpi_from_fifo.v
+      # - bsg_test/bsg_nonsynth_ascii_writer.v
+      # - bsg_test/bsg_nonsynth_dramsim3.v
+      - bsg_test/bsg_nonsynth_dpi_clock_gen.v
+      - bsg_dmc/bsg_dmc.v
+      - bsg_dmc/bsg_dmc_controller.v
+      - bsg_dmc/bsg_dmc_phy.v
+      - bsg_dmc/bsg_dmc_clk_rst_gen.v
+      - bsg_clk_gen/bsg_nonsynth_clk_watcher.v
+      - bsg_clk_gen/bsg_dram_clk_gen.v
+      - bsg_clk_gen/bsg_dly_line.v
+      - bsg_clk_gen/bsg_clk_gen.v
+      - bsg_clk_gen/bsg_clk_gen_osc.v
+      - bsg_clk_gen/bsg_edge_balanced_mux4.v
+      # - bsg_comm_link/master_calib_skip/bsg_comm_link_master_calib_skip_rom.v
+      - bsg_comm_link/master_calib_skip/bsg_source_sync_channel_control_master.v
+      - bsg_comm_link/master_calib_skip/bsg_source_sync_channel_control_master_master.v
+      # - bsg_comm_link/test_bsg_comm_link_checker.v
+      - bsg_comm_link/bsg_assembler_in.v
+      - bsg_comm_link/bsg_source_sync_channel_control_master.v
+      - bsg_comm_link/bsg_source_sync_output.v
+      - bsg_comm_link/bsg_source_sync_input.v
+      - bsg_comm_link/bsg_source_sync_channel_control_slave.v
+      - bsg_comm_link/bsg_comm_link.v
+      - bsg_comm_link/bsg_source_sync_channel_control_master_master.v
+      - bsg_comm_link/bsg_assembler_out.v
+      # - bsg_comm_link/tests/test_bsg_comm_link/test_bsg_comm_link.v
+      # - bsg_comm_link/tests/test_bsg_assembler/test_bsg_assembler.v
+      # - bsg_comm_link/tests/test_bsg_source_sync/test_bsg_source_sync.v
+      # - bsg_legacy/bsg_murn_converter.v
+      - bsg_async/bsg_async_fifo.v
+      - bsg_async/bsg_sync_sync.v
+      - bsg_async/bsg_async_credit_counter.v
+      - bsg_async/bsg_launch_sync_sync.v
+      - bsg_async/bsg_async_ptr_gray.v
+      - bsg_misc/bsg_latch.v
+      - bsg_misc/bsg_arb_fixed.v
+      - bsg_misc/bsg_id_pool.v
+      - bsg_misc/bsg_mul/bsg_mul_comp42.v
+      - bsg_misc/bsg_mul/bsg_mul_booth_4_block_rep.v
+      - bsg_misc/bsg_mul/bsg_mul_comp42_rep.v
+      - bsg_misc/bsg_mul/bsg_mul_booth_4_block.v
+      - bsg_misc/bsg_rotate_left.v
+      - bsg_misc/bsg_scheduler_dataflow.v
+      - bsg_misc/bsg_imul_iterative.v
+      - bsg_misc/bsg_lru_pseudo_tree_encode.v
+      - bsg_misc/bsg_adder_one_hot.v
+      - bsg_misc/bsg_mux_bitwise.v
+      # - bsg_misc/bsg_sparse_to_dense_boolean.v
+      - bsg_misc/bsg_dff_async_reset.v
+      - bsg_misc/bsg_mux_one_hot.v
+      - bsg_misc/bsg_lru_pseudo_tree_backup.v
+      - bsg_misc/bsg_crossbar_control_basic_o_by_i.v
+      - bsg_misc/bsg_priority_encode_one_hot_out.v
+      - bsg_misc/bsg_edge_detect.v
+      - bsg_misc/bsg_concentrate_static.v
+      - bsg_misc/bsg_lru_pseudo_tree_decode.v
+      - bsg_misc/bsg_counter_set_en.v
+      - bsg_misc/bsg_unconcentrate_static.v
+      - bsg_misc/bsg_mul_synth.v
+      - bsg_misc/bsg_crossbar_o_by_i.v
+      - bsg_misc/bsg_counting_leading_zeros.v
+      - bsg_misc/bsg_priority_encode.v
+      - bsg_misc/bsg_gray_to_binary.v
+      - bsg_misc/bsg_dff.v
+      - bsg_misc/bsg_inv.v
+      - bsg_misc/bsg_circular_ptr.v
+      - bsg_misc/bsg_arb_round_robin.v
+      - bsg_misc/bsg_counter_dynamic_limit.v
+      - bsg_misc/bsg_xor.v
+      - bsg_misc/bsg_counter_up_down.v
+      - bsg_misc/bsg_level_shift_up_down_sink.v
+      - bsg_misc/bsg_id_pool_dealloc_alloc_one_hot.v
+      - bsg_misc/bsg_mul_array.v
+      - bsg_misc/bsg_nor3.v
+      - bsg_misc/bsg_mux.v
+      - bsg_misc/bsg_tielo.v
+      - bsg_misc/bsg_dff_reset_en.v
+      - bsg_misc/bsg_counter_set_down.v
+      - bsg_misc/bsg_reduce_segmented.v
+      - bsg_misc/bsg_dff_reset_en_bypass.v
+      - bsg_misc/bsg_thermometer_count.v
+      - bsg_misc/bsg_counter_dynamic_limit_en.v
+      - bsg_misc/bsg_adder_cin.v
+      - bsg_misc/bsg_mul.v
+      - bsg_misc/bsg_array_reverse.v
+      - bsg_misc/bsg_mux2_gatestack.v
+      - bsg_misc/bsg_dff_negedge_reset.v
+      - bsg_misc/bsg_abs.v
+      - bsg_misc/bsg_icg_pos.v
+      - bsg_misc/bsg_counter_clock_downsample.v
+      - bsg_misc/bsg_transpose_reduce.v
+      - bsg_misc/bsg_nor2.v
+      - bsg_misc/bsg_encode_one_hot.v
+      - bsg_misc/bsg_mux_segmented.v
+      - bsg_misc/bsg_clkbuf.v
+      - bsg_misc/bsg_crossbar_control_locking_o_by_i.v
+      - bsg_misc/bsg_dlatch.v
+      - bsg_misc/bsg_level_shift_up_down_source.v
+      - bsg_misc/bsg_hash_bank.v
+      - bsg_misc/bsg_reduce.v
+      - bsg_misc/bsg_muxi2_gatestack.v
+      - bsg_misc/bsg_counter_clear_up.v
+      - bsg_misc/bsg_idiv_iterative_controller.v
+      - bsg_misc/bsg_dff_reset_set_clear.v
+      - bsg_misc/bsg_lfsr.v
+      - bsg_misc/bsg_mux_butterfly.v
+      - bsg_misc/bsg_tiehi.v
+      - bsg_misc/bsg_transpose.v
+      - bsg_misc/bsg_counter_overflow_set_en.v
+      - bsg_misc/bsg_buf.v
+      - bsg_misc/bsg_locking_arb_fixed.v
+      - bsg_misc/bsg_strobe.v
+      - bsg_misc/bsg_clkgate_optional.v
+      - bsg_misc/bsg_mul_array_row.v
+      - bsg_misc/bsg_swap.v
+      - bsg_misc/bsg_dff_en.v
+      - bsg_misc/bsg_and.v
+      - bsg_misc/bsg_mul_pipelined.v
+      - bsg_misc/bsg_adder_ripple_carry.v
+      - bsg_misc/bsg_pg_tree.v
+      - bsg_misc/bsg_decode_with_v.v
+      - bsg_misc/bsg_dff_reset.v
+      - bsg_misc/bsg_cycle_counter.v
+      - bsg_misc/bsg_scan.v
+      - bsg_misc/bsg_decode.v
+      - bsg_misc/bsg_wait_cycles.v
+      - bsg_misc/bsg_dff_en_bypass.v
+      - bsg_misc/bsg_counter_clear_up_one_hot.v
+      - bsg_misc/bsg_mul_add_unsigned.v
+      - bsg_misc/bsg_dff_chain.v
+      - bsg_misc/bsg_icg_neg.v
+      - bsg_misc/bsg_array_concentrate_static.v
+      - bsg_misc/bsg_rotate_right.v
+      - bsg_misc/bsg_less_than.v
+      - bsg_misc/bsg_idiv_iterative.v
+      - bsg_misc/bsg_xnor.v
+      - bsg_misc/bsg_counter_overflow_en.v
+      - bsg_misc/bsg_nand.v
+      - bsg_misc/bsg_popcount.v
+      - bsg_misc/bsg_dff_gatestack.v
+      - bsg_misc/bsg_round_robin_arb.v
+      - bsg_misc/bsg_binary_plus_one_to_gray.v
+      - bsg_misc/bsg_buf_ctrl.v
+      - bsg_misc/bsg_hash_bank_reverse.v
+      - bsg_misc/bsg_counter_up_down_variable.v
+      - bsg_misc/bsg_expand_bitmask.v
+      - bsg_misc/bsg_wait_after_reset.v
+      - bsg_noc/bsg_mesh_router_decoder_dor.v
+      - bsg_noc/bsg_noc_repeater_node.v
+      - bsg_noc/bsg_mesh_router_buffered.v
+      - bsg_noc/bsg_wormhole_router_adapter_in.v
+      - bsg_noc/bsg_barrier.v
+      - bsg_noc/bsg_wormhole_router_input_control.v
+      - bsg_noc/bsg_router_crossbar_o_by_i.v
+      - bsg_noc/bsg_wormhole_router_adapter_out.v
+      - bsg_noc/bsg_wormhole_router.v
+      - bsg_noc/bsg_mesh_stitch.v
+      - bsg_noc/bsg_mesh_to_ring_stitch.v
+      - bsg_noc/bsg_wormhole_concentrator.v
+      - bsg_noc/bsg_wormhole_concentrator_in.v
+      - bsg_noc/bsg_wormhole_router_adapter.v
+      - bsg_noc/bsg_mesh_router.v
+      - bsg_noc/bsg_wormhole_concentrator_out.v
+      - bsg_noc/bsg_wormhole_router_output_control.v
+      - bsg_noc/bsg_wormhole_router_decoder_dor.v
+      - bsg_noc/bsg_ready_and_link_async_to_wormhole.v
+      # - bsg_chip/bsg_nonsynth_mixin_motherboard.v
+      # - bsg_chip/bsg_rocket/bsg_rocket_core_fsb.v
+      # - bsg_chip/bsg_rocket/bsg_chip_rocket.v
+      # - bsg_chip/bsg_rocket/bsg_nonsynth_chipset_rocket_fsb.v
+      # - bsg_mesosync_io/src/bsg_logic_analyzer.v
+      # - bsg_mesosync_io/src/bsg_mesosync_link.v
+      # - bsg_mesosync_io/src/bsg_mesosync_output.v
+      # - bsg_mesosync_io/src/definitions.v
+      # - bsg_mesosync_io/src/bsg_ddr_sampler.v
+      # - bsg_mesosync_io/src/bsg_mesosync_input.v
+      # - bsg_mesosync_io/src/bsg_mesosync_core.v
+      # - bsg_mesosync_io/tests/mesosynctb_gate_level.v
+      # - bsg_mesosync_io/tests/mesosynctb.v
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets: [rtl]
+
+provider :
+  name : github
+  user : bespoke-silicon-group
+  repo : basejump_stl


### PR DESCRIPTION
Hello!

Because of [this FuseSoC comfort/performance issue](https://github.com/olofk/fusesoc/issues/589#issue-1402379560), I created a large single FuseSoC core to run dependency management tasks faster.
I am not certain whether this repo is the correct place for this core. The incentive is that if the FuseSoC issue persists, then this will serve as an example for other projects. We may however prefer to put this core in the black parrot repo (or nowhere at all :smile: ). What do you think?